### PR TITLE
Metric batching

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -26,8 +26,9 @@ services:
 
 networks:
   inspectornet:
+    name: inspectornet
     driver: bridge
 
 volumes:
   influx-data:
-
+    name: influx-data

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-var METRIC_CHANNEL_POLL_INTERVAL = 2 * time.Second
+var METRIC_CHANNEL_POLL_INTERVAL = 10 * time.Second
 var TARGET_LIST_SCAN_WAIT_INTERVAL = 4 * time.Second
 var PROBER_RESTART_INTERVAL_JITTER_RANGE = 2
 var METRIC_CHANNEL_SIZE = 400
@@ -68,10 +68,11 @@ func main() {
 			select {
 			case m := <-metricsChannel:
 				m.Tags["region"] = c.Inspector.Region
-				mdb.EmitSingle(m)
+				mdb.CollectMetrics(m)
 			default:
 				mylogger.MainLogger.Infof("Metrics channel is empty. Waiting some more...")
 				time.Sleep(METRIC_CHANNEL_POLL_INTERVAL)
+				mdb.EmitMultiple() 
 			}
 		}
 	}()

--- a/metrics/general.go
+++ b/metrics/general.go
@@ -16,6 +16,8 @@ type SingleMetric struct {
 type MetricsDB interface {
 	InitializeClient(addr string, port int, database string) error
 	EmitSingle(m SingleMetric)
+	CollectMetrics(m SingleMetric)
+	EmitMultiple()
 }
 
 func CreateSingleMetric(name string, value int64, additionalFields map[string]interface{}, tags map[string]string) SingleMetric {


### PR DESCRIPTION
Added `CollectMetrics` and `EmitMultiple` methods for batching and sending metrics in bulk to the database, reducing write operations and improving performance.