### PR TITLE
Continious Queries for Influx 1.8

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,11 @@ func main() {
 		mylogger.MainLogger.Infof("Failed initializing metrics db client with error: %s", err)
 		os.Exit(1)
 	}
+	err = mdb.LaunchAggregation()
+	if err != nil {
+		mylogger.MainLogger.Infof("Failed initializing metrics db data aggregation error: %s", err)
+		os.Exit(1)
+	}
 	mylogger.MainLogger.Infof("Initialized metrics database...")
 
 	// Tracking the config to be able to inform the inspector about changes, this makes the inspector self-updating while running.

--- a/metrics/general.go
+++ b/metrics/general.go
@@ -18,6 +18,7 @@ type MetricsDB interface {
 	EmitSingle(m SingleMetric)
 	CollectMetrics(m SingleMetric)
 	EmitMultiple()
+	LaunchAggregation() error
 }
 
 func CreateSingleMetric(name string, value int64, additionalFields map[string]interface{}, tags map[string]string) SingleMetric {
@@ -29,8 +30,8 @@ func CreateSingleMetric(name string, value int64, additionalFields map[string]in
 	}
 }
 
-// NewMetricsDB initializes a metrics database specified by the config. It returns an object that implements the MetricsDB
-// interface. Currently only InfluxDB is supported.
+// NewMetricsDB initializes a metrics database specified by the config.
+// Currently, only InfluxDB is supported.
 func NewMetricsDB(c config.MetricsDBSubConfig) (MetricsDB, error) {
 	var mdb MetricsDB
 	if c.InfluxDBSubConfig != nil {
@@ -41,7 +42,7 @@ func NewMetricsDB(c config.MetricsDBSubConfig) (MetricsDB, error) {
 		}
 	} else {
 		mylogger.MainLogger.Errorf("Specified metrics database is not supported in config: %v", c)
-		return nil, fmt.Errorf("MetricsDB defiend in configuration is not supported: %v", c)
+		return nil, fmt.Errorf("MetricsDB defined in configuration is not supported: %v", c)
 	}
 	return mdb, nil
 }

--- a/metrics/influxdb.go
+++ b/metrics/influxdb.go
@@ -1,17 +1,16 @@
+// influxdb.go
 package metrics
 
 import (
 	"fmt"
-	influxdb_client "github.com/influxdata/influxdb1-client/v2"
 	"os"
 	"time"
+
+	influxdb_client "github.com/influxdata/influxdb1-client/v2"
+	"inspector/mylogger"
 )
 
-/*
- * Implementation of metrics collectors.
- * Currently only InfluxDB is supported.
- */
-
+// InfluxDB implements the MetricsDB interface for InfluxDB.
 type InfluxDB struct {
 	client   influxdb_client.Client
 	addr     string
@@ -20,111 +19,216 @@ type InfluxDB struct {
 	metrics  []*influxdb_client.Point
 }
 
-// InitializeClient creates a new HTTP based InfluxDB client. This client will be used for the lifetime of the application.
-func (flxDB *InfluxDB) InitializeClient(addr string, port int, database string) error {
+// InitializeClient creates a new HTTP-based InfluxDB client.
+func (db *InfluxDB) InitializeClient(addr string, port int, database string) error {
 	var err error
-	flxDB.client, err = influxdb_client.NewHTTPClient(influxdb_client.HTTPConfig{
+	db.client, err = influxdb_client.NewHTTPClient(influxdb_client.HTTPConfig{
 		Addr: fmt.Sprintf("http://%s:%d", addr, port),
 	})
 	if err != nil {
 		return err
 	}
-	flxDB.port = port
-	flxDB.addr = addr
-	flxDB.database = database
-	flxDB.metrics = make([]*influxdb_client.Point, 0)
+	db.addr = addr
+	db.port = port
+	db.database = database
+	db.metrics = make([]*influxdb_client.Point, 0)
 	return nil
 }
 
-// EmitSingle sends a single metric out using the current InfluxDB client. It adds the source host where the metric is coming from.
-func (flxDB *InfluxDB) EmitSingle(m SingleMetric) {
+// EmitSingle sends a single metric to InfluxDB.
+func (db *InfluxDB) EmitSingle(m SingleMetric) {
+	db.collectMetric(m)
+	db.EmitMultiple()
+}
+
+// CollectMetrics accumulates metrics for batch sending.
+func (db *InfluxDB) CollectMetrics(m SingleMetric) {
+	db.collectMetric(m)
+}
+
+// collectMetric prepares a metric point for sending.
+func (db *InfluxDB) collectMetric(m SingleMetric) {
 	if m.Tags == nil {
 		m.Tags = make(map[string]string)
+	}
+	if _, ok := m.Tags["host"]; !ok {
 		m.Tags["host"], _ = os.Hostname()
 	}
-	_, ok := m.Tags["host"]
-	if !ok {
-		m.Tags["host"], _ = os.Hostname()
-	}
-	// additionalFields cannot be empty
 	if m.AdditionalFields == nil {
 		m.AdditionalFields = make(map[string]interface{})
 	}
 	m.AdditionalFields["value"] = m.Value
-	point, err := influxdb_client.NewPoint(m.Name,
-		m.Tags,
-		m.AdditionalFields,
-		time.Now())
+
+	point, err := influxdb_client.NewPoint(m.Name, m.Tags, m.AdditionalFields, time.Now())
 	if err != nil {
-		fmt.Printf("Error creating point: %s\n", err)
+		mylogger.MainLogger.Errorf("Error creating point: %s", err)
 		return
 	}
-
-	bp, err := influxdb_client.NewBatchPoints(influxdb_client.BatchPointsConfig{
-		Database:  flxDB.database,
-		Precision: "ns",
-	})
-	if err != nil {
-		fmt.Printf("Error creating batch points: %s\n", err)
-		return
-	}
-	bp.AddPoint(point)
-
-	// Send the batch of points to InfluxDB
-	err = flxDB.client.Write(bp)
-	if err != nil {
-		fmt.Printf("Error writing to InfluxDB: %s\n", err)
-	}
+	db.metrics = append(db.metrics, point)
 }
 
-// CollectMetrics accumulates metrics for subsequent sending.
-func (flxDB *InfluxDB) CollectMetrics(m SingleMetric) {
-	if m.Tags == nil {
-		m.Tags = make(map[string]string)
-		m.Tags["host"], _ = os.Hostname()
-	}
-	_, ok := m.Tags["host"]
-	if !ok {
-		m.Tags["host"], _ = os.Hostname()
-	}
-	// additionalFields cannot be empty
-	if m.AdditionalFields == nil {
-		m.AdditionalFields = make(map[string]interface{})
-	}
-	m.AdditionalFields["value"] = m.Value
-	point, err := influxdb_client.NewPoint(m.Name,
-		m.Tags,
-		m.AdditionalFields,
-		time.Now())
-	if err != nil {
-		fmt.Printf("Error creating point: %s\n", err)
-		return
-	}
-	flxDB.metrics = append(flxDB.metrics, point)
-}
-
-// EmitMultiple sends all accumulated metrics to InfluxDB in one request.
-func (flxDB *InfluxDB) EmitMultiple() {
-	if len(flxDB.metrics) == 0 {
+// EmitMultiple sends all accumulated metrics to InfluxDB.
+func (db *InfluxDB) EmitMultiple() {
+	if len(db.metrics) == 0 {
 		return
 	}
 	bp, err := influxdb_client.NewBatchPoints(influxdb_client.BatchPointsConfig{
-		Database:  flxDB.database,
+		Database:  db.database,
 		Precision: "ns",
 	})
 	if err != nil {
-		fmt.Printf("Error creating batch points: %s\n", err)
+		mylogger.MainLogger.Errorf("Error creating batch points: %s", err)
 		return
 	}
-	bp.AddPoints(flxDB.metrics)
+	bp.AddPoints(db.metrics)
 
-	// Send the batch of points to InfluxDB
-	err = flxDB.client.Write(bp)
+	if err = db.client.Write(bp); err != nil {
+		mylogger.MainLogger.Errorf("Error writing to InfluxDB: %s", err)
+		return
+	}
+	db.metrics = db.metrics[:0]
+}
+
+// LaunchAggregation sets up retention policies and continuous queries.
+func (db *InfluxDB) LaunchAggregation() error {
+	if err := db.createRetentionPolicy(); err != nil {
+		mylogger.MainLogger.Errorf("Failed to create retention policy: %s", err)
+		return err
+	}
+
+	if err := db.createContinuousQueries(); err != nil {
+		mylogger.MainLogger.Errorf("Failed to create continuous queries: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+// createRetentionPolicy creates a retention policy for aggregated data.
+func (db *InfluxDB) createRetentionPolicy() error {
+	query := fmt.Sprintf(`CREATE RETENTION POLICY "report" ON "%s" DURATION 30d REPLICATION 1`, db.database)
+	return db.executeQuery(query)
+}
+
+// createContinuousQueries creates continuous queries for data aggregation.
+func (db *InfluxDB) createContinuousQueries() error {
+	measurements := []string{"certificate_expiration", "connect_time", "response_time", "status"}
+
+	for _, measurement := range measurements {
+		var queries []string
+
+		switch measurement {
+		case "certificate_expiration":
+			queries = db.certificateExpirationQueries(measurement)
+		case "connect_time", "response_time":
+			queries = db.latencyQueries(measurement)
+		case "status":
+			queries = db.statusQueries(measurement)
+		default:
+			mylogger.MainLogger.Errorf("No continuous queries defined for measurement: %s", measurement)
+			continue
+		}
+
+		for _, q := range queries {
+			if err := db.executeQuery(q); err != nil {
+				mylogger.MainLogger.Errorf("Failed to execute query for measurement %s: %s", measurement, err)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// executeQuery runs a query against InfluxDB.
+func (db *InfluxDB) executeQuery(query string) error {
+	q := influxdb_client.Query{
+		Command:  query,
+		Database: db.database,
+	}
+	response, err := db.client.Query(q)
 	if err != nil {
-		fmt.Printf("Error writing to InfluxDB: %s\n", err)
-		return
+		return err
 	}
+	if response.Error() != nil {
+		return response.Error()
+	}
+	return nil
+}
 
-	// Clear the accumulated metrics after successful sending
-	flxDB.metrics = flxDB.metrics[:0]
+// certificateExpirationQueries generates continuous queries for certificate expiration.
+func (db *InfluxDB) certificateExpirationQueries(measurement string) []string {
+	query := fmt.Sprintf(
+		`CREATE CONTINUOUS QUERY cq_%s ON "%s" BEGIN
+			SELECT LAST(value) AS days_left
+			INTO "%s"."report"."%s"
+			FROM "%s"."autogen"."%s"
+			GROUP BY time(1m), target_id, prober_id, region, host
+		END`,
+		measurement, db.database, db.database, measurement, db.database, measurement,
+	)
+	return []string{query}
+}
+
+// latencyQueries generates continuous queries for latency measurements.
+func (db *InfluxDB) latencyQueries(measurement string) []string {
+	query := fmt.Sprintf(
+		`CREATE CONTINUOUS QUERY cq_%s ON "%s" BEGIN
+			SELECT 
+				ROUND(MEAN(value) * 100) / 100 AS avg_time,
+				ROUND(MIN(value) * 100) / 100 AS min_time,
+				ROUND(MAX(value) * 100) / 100 AS max_time,
+				ROUND(STDDEV(value) * 100) / 100 AS stddev_time,
+				ROUND(MEDIAN(value) * 100) / 100 AS median,
+				ROUND(PERCENTILE(value, 90) * 100) / 100 AS p90_time,
+				ROUND(PERCENTILE(value, 95) * 100) / 100 AS p95_time,
+				ROUND(PERCENTILE(value, 99) * 100) / 100 AS p99_time
+			INTO "%s"."report"."%s"
+			FROM "%s"."autogen"."%s"
+			GROUP BY time(1m), target_id, prober_id, region, host
+		END`,
+		measurement, db.database, db.database, measurement, db.database, measurement,
+	)
+	return []string{query}
+}
+
+// statusQueries generates continuous queries for status-related measurements.
+func (db *InfluxDB) statusQueries(measurement string) []string {
+	baseQuery := func(cqName, condition, fieldAlias string) string {
+		return fmt.Sprintf(
+			`CREATE CONTINUOUS QUERY %s ON "%s" BEGIN
+				SELECT COUNT(value) AS %s
+				INTO "%s"."report"."%s"
+				FROM "%s"."autogen"."%s"
+				WHERE %s
+				GROUP BY time(1m), target_id, prober_id, region, host
+			END`,
+			cqName,
+			db.database,
+			fieldAlias,
+			db.database,
+			measurement,
+			db.database,
+			measurement,
+			condition,
+		)
+	}
+	
+	successQuery := baseQuery(
+		"cq_status_success",
+		`value >= 200 AND value < 300`,
+		"success_requests",
+	)
+	failQuery := baseQuery(
+		"cq_status_fail",
+		`value < 200 OR value >= 300`,
+		"failed_requests",
+	)
+	totalQuery := baseQuery(
+		"cq_status_total",
+		`TRUE`,
+		"total_requests",
+	)
+	
+	return []string{successQuery, failQuery, totalQuery}
 }


### PR DESCRIPTION
The data must be aggregated somewhere. To solve this issue continuous queries will serve. Thet will be launched in the background and will periodically aggregate data and save it in a separate retention policy (normally, data in influx 1.8 is saved in  `autogen` retention. We will save aggregated data in `report` retention.